### PR TITLE
Making it possible to add custom request properties to CLS namespace.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ export interface IOptions {
   useHeader?: boolean
   // Default: 'X-Request-Id'
   headerName?: string
+  // Default: undefined
+  customNamespacePropertiesBuilder?: (request: any, namespace: any) => void
 }
 
 export interface IHapiPlugin<T> {

--- a/tests/express.test.js
+++ b/tests/express.test.js
@@ -257,4 +257,31 @@ describe('cls-rtracer for Express', () => {
       expect(id1).not.toEqual(id2)
     })
   })
+
+  test('generates custom namespace property for request', () => {
+    const app = express()
+    const propertyName = 'originalUrl'
+
+    app.use(rTracer.expressMiddleware({
+      customNamespacePropertiesBuilder: (request, namespace) => {
+        namespace.set(propertyName, request.originalUrl)
+      }
+    }))
+
+    let propertyValue
+
+    const requestUrl = '/test'
+    app.get(requestUrl, (req, res) => {
+      propertyValue = rTracer.getNamespaceProperty(propertyName)
+      res.json({ propertyValue })
+    })
+
+    return request(app).get(requestUrl)
+      .then(res => {
+        expect(res.statusCode).toBe(200)
+        expect(propertyValue).toEqual(requestUrl)
+        expect(res.body.propertyValue).toEqual(requestUrl)
+        expect(res.body.propertyValue.length).toBeGreaterThan(0)
+      })
+  })
 })

--- a/tests/koa.test.js
+++ b/tests/koa.test.js
@@ -222,4 +222,31 @@ describe('cls-rtracer for Koa', () => {
       expect(id1).not.toEqual(id2)
     })
   })
+
+  test('generates custom namespace property for request', () => {
+    const app = new Koa()
+    const propertyName = 'originalUrl'
+
+    app.use(rTracer.koaMiddleware({
+      customNamespacePropertiesBuilder: (request, namespace) => {
+        namespace.set(propertyName, request.url)
+      }
+    }))
+
+    let propertyValue
+
+    const requestUrl = '/test'
+    app.use((ctx) => {
+      propertyValue = rTracer.getNamespaceProperty(propertyName)
+      ctx.body = { propertyValue }
+    })
+
+    return request(app.callback()).get(requestUrl)
+      .then(res => {
+        expect(res.statusCode).toBe(200)
+        expect(propertyValue).toEqual(requestUrl)
+        expect(res.body.propertyValue).toEqual(requestUrl)
+        expect(res.body.propertyValue.length).toBeGreaterThan(0)
+      })
+  })
 })

--- a/tests/koav1.test.js
+++ b/tests/koav1.test.js
@@ -185,4 +185,31 @@ describe('cls-rtracer for Koa v1', () => {
       expect(id1).not.toEqual(id2)
     })
   })
+
+  test('generates custom namespace property for request', () => {
+    const app = new Koa()
+    const propertyName = 'originalUrl'
+
+    app.use(rTracer.koaV1Middleware({
+      customNamespacePropertiesBuilder: (request, namespace) => {
+        namespace.set(propertyName, request.url)
+      }
+    }))
+
+    let propertyValue
+
+    const requestUrl = '/test'
+    app.use(function * () {
+      propertyValue = rTracer.getNamespaceProperty(propertyName)
+      this.body = { propertyValue }
+    })
+
+    return request(app.callback()).get(requestUrl)
+      .then(res => {
+        expect(res.statusCode).toBe(200)
+        expect(propertyValue).toEqual(requestUrl)
+        expect(res.body.propertyValue).toEqual(requestUrl)
+        expect(res.body.propertyValue.length).toBeGreaterThan(0)
+      })
+  })
 })


### PR DESCRIPTION
Hi, 

It would be awesome to add custom request properties into the CLS namespace, besides the request ID header.

This PR makes it possible by adding a new option to the middleware, a custom namespace properties builder function. This function receives the current request and CLS namespace variable so that client code can add any needed new properties based on the request.

If you like the idea, please feel free to make any changes in the PR.

I'm looking forward to use this new feature, otherwise I'll need to implement again 🙈 . 

Best regards!