### PR TITLE
fix: `runWithId` should return the type of the function passed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,6 @@ export declare const koaV1Middleware: (
 
 export declare const hapiPlugin: IHapiPlugin<IOptions>
 
-export declare function runWithId<T>(fn: () => T, id?: string): T
+export declare function runWithId<T>(fn: () => T, id?: unknown): T
 
-export declare const id: () => string | undefined
+export declare const id: () => unknown | undefined

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,6 @@ export declare const koaV1Middleware: (
 
 export declare const hapiPlugin: IHapiPlugin<IOptions>
 
-export declare const runWithId: (fn: Function, id?: any) => any
+export declare function runWithId<T>(fn: () => T, id?: string): T
 
 export declare const id: () => string | undefined


### PR DESCRIPTION
Otherwise doing `const thing = rTracer.runWithId(() => '42')` would be type `any`. With this PR the type is `string`