### PR TITLE
Migrate from factory function to single instance of Fastify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ Use the plugin provided by the library:
 const fastify = require('fastify')()
 const rTracer = require('cls-rtracer')
 
-// any third party middleware that does not need access to request ids goes here
+// any third party plugin that does not need access to request ids goes here
 // ...
 
-fastify.use(rTracer.fastifyPlugin())
-// optionally, you can override default middleware config:
-// fastify.use(rTracer.fastifyPlugin({
+fastify.register(rTracer.fastifyPlugin)
+// optionally, you can override default plugin config:
+// fastify.register(rTracer.fastifyPlugin, {
 //   useHeader: true,
 //   headerName: 'X-Your-Request-Header',
 //   useFastifyRequestId: true
 // }))
 
-// all code in middlewares, starting from here, has access to request ids
+// all code in plugins or handlers, starting from here, has access to request ids
 ```
 
 Obtain request id in middlewares on the incoming request:
@@ -204,12 +204,12 @@ const init = async () => {
   // ...
 
   await server.register({
-    plugin: rtracer.hapiPlugin
+    plugin: rTracer.hapiPlugin
   })
 
   // optionally, you can override default middleware config:
   //  await server.register({
-  //    plugin: rtracer.hapiPlugin,
+  //    plugin: rTracer.hapiPlugin,
   //    options: {
   //      useHeader: true,
   //      headerName: 'X-Your-Request-Header'

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,10 +31,8 @@ export declare const expressMiddleware: (
 ) => void
 
 export declare const fastifyPlugin: (
-  options?: IFastifyOptions,
-) => (
   fastify: any,
-  options: any,
+  options: IFastifyOptions,
   done: (err?: any) => void,
 ) => void
 

--- a/samples/fastify.winston.js
+++ b/samples/fastify.winston.js
@@ -28,7 +28,7 @@ const logger = createLogger({
 const Fastify = require('fastify')
 const app = new Fastify()
 
-app.register(rTracer.fastifyPlugin())
+app.register(rTracer.fastifyPlugin)
 
 app.get('/', async (request, reply) => {
   logger.info('Starting request handling')

--- a/tests/fastify.test.js
+++ b/tests/fastify.test.js
@@ -13,7 +13,7 @@ const types = [pluginType, middlewareType]
 const register = (type, app, options) => {
   switch (type) {
     case pluginType:
-      return app.register(rTracer.fastifyPlugin(options))
+      return app.register(rTracer.fastifyPlugin, options)
     case middlewareType:
       return app.use(rTracer.fastifyMiddleware(options))
     default:


### PR DESCRIPTION
* Also fixes misprints in readme.

Important note: this PR breaks compatibility of Fastify plugin, but as the plugin was introduced recently it should be ok to include this change into a minor version release.