### PR TITLE
feat(koa): echo header in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ app.use(rTracer.koaMiddleware())
 // app.use(rTracer.koaMiddleware({
 //   useHeader: true,
 //   headerName: 'X-Your-Request-Header'
+// Use this to inject the id into the response as the `headerName` header
+//   echoHeader: true
 // }))
 
 // all code in middlewares, starting from here, has access to request ids

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,11 @@ export interface IOptions {
   requestIdFactory?: RequestIdFactory
 }
 
+export interface IKoaOptions extends IOptions {
+  // Default: false
+  echoHeader?: boolean
+}
+
 export interface IFastifyOptions {
   // Default: false
   useHeader?: boolean
@@ -51,7 +56,7 @@ export declare const fastifyMiddleware: (
 ) => void
 
 export declare const koaMiddleware: (
-  options?: IOptions,
+  options?: IKoaOptions,
 ) => (
   ctx: { request: IncomingMessage; response: ServerResponse },
   next: () => Promise<void>,

--- a/src/rtracer.js
+++ b/src/rtracer.js
@@ -92,6 +92,8 @@ fastifyPlugin[Symbol.for('fastify.display-name')] = pluginName
  * @param {Object} options possible options
  * @param {boolean} options.useHeader respect request header flag
  *                                    (default: `false`)
+ * @param {boolean} options.echoHeader injects `headerName` header into the response
+ *                                    (default: `false`)
  * @param {string} options.headerName request header name, used if `useHeader` is set to `true`
  *                                    (default: `X-Request-Id`)
  * @param {function} options.requestIdFactory function used to generate request ids
@@ -100,7 +102,8 @@ fastifyPlugin[Symbol.for('fastify.display-name')] = pluginName
 const koaMiddleware = ({
   useHeader = false,
   headerName = 'X-Request-Id',
-  requestIdFactory = uuidv1
+  requestIdFactory = uuidv1,
+  echoHeader = false
 } = {}) => {
   return (ctx, next) => {
     let requestId
@@ -108,6 +111,10 @@ const koaMiddleware = ({
       requestId = ctx.request.headers[headerName.toLowerCase()]
     }
     requestId = requestId || requestIdFactory()
+
+    if (echoHeader) {
+      ctx.set(headerName, requestId)
+    }
 
     return als.run(requestId, () => {
       wrapHttpEmitters(ctx.req, ctx.res)

--- a/tests/koa.test.js
+++ b/tests/koa.test.js
@@ -262,4 +262,61 @@ describe('cls-rtracer for Koa', () => {
       expect(id1).not.toEqual(id2)
     })
   })
+
+  test('does not echo the header when the option is not set', () => {
+    const app = new Koa()
+    app.use(rTracer.koaMiddleware())
+
+    let id
+
+    app.use((ctx) => {
+      id = rTracer.id()
+      ctx.body = { id }
+    })
+
+    return request(app.callback()).get('/')
+      .then(res => {
+        expect(res.statusCode).toBe(200)
+        expect(res.headers['x-request-id']).toEqual(undefined)
+      })
+  })
+
+  test('echoes the header when the option is set', () => {
+    const app = new Koa()
+    app.use(rTracer.koaMiddleware({ echoHeader: true }))
+
+    let id
+
+    app.use((ctx) => {
+      id = rTracer.id()
+      ctx.body = { id }
+    })
+
+    return request(app.callback()).get('/')
+      .then(res => {
+        expect(res.statusCode).toBe(200)
+        expect(res.headers['x-request-id']).toEqual(id)
+      })
+  })
+
+  test('echoes the header when the option is set and a custom header is defined', () => {
+    const app = new Koa()
+    app.use(rTracer.koaMiddleware({
+      echoHeader: true, 
+      headerName: 'x-another-req-id'
+    }))
+
+    let id
+
+    app.use((ctx) => {
+      id = rTracer.id()
+      ctx.body = { id }
+    })
+
+    return request(app.callback()).get('/')
+      .then(res => {
+        expect(res.statusCode).toBe(200)
+        expect(res.headers['x-another-req-id']).toEqual(id)
+      })
+  })
 })


### PR DESCRIPTION
Setting `echoHeader: true` in the `koaMiddleware` options will inject
the header (respecting `headerName`) in the response headers.

Relates to #1