### PR TITLE
fix: Hapi plugin could not echo header for error responses

### DIFF
--- a/src/rtracer.js
+++ b/src/rtracer.js
@@ -221,7 +221,7 @@ const hapiPlugin = ({
 
     if (echoHeader) {
       server.ext('onPreResponse', async (request, h) => {
-        if (request.response.isBoom) {
+        if (request.response.output) { // Response is a Boom error
           request.response.output.headers[headerName] = id()
         } else {
           request.response.header(headerName, id())

--- a/src/rtracer.js
+++ b/src/rtracer.js
@@ -221,7 +221,11 @@ const hapiPlugin = ({
 
     if (echoHeader) {
       server.ext('onPreResponse', async (request, h) => {
-        request.response.header(headerName, id())
+        if (request.response && request.response.header) {
+          request.response.header(headerName, id())
+        } else if (request.response && request.response.output && request.response.output.headers) {
+          request.response.output.headers[headerName] = id()
+        }
         return h.continue
       })
     }

--- a/src/rtracer.js
+++ b/src/rtracer.js
@@ -221,7 +221,11 @@ const hapiPlugin = ({
 
     if (echoHeader) {
       server.ext('onPreResponse', async (request, h) => {
-        request.raw.res.setHeader(headerName, id())
+        if (request.response && request.response.header) {
+          request.response.header(headerName, id())
+        } else if (request.response && request.response.output && request.response.output.headers) {
+          request.response.output.headers[headerName] = id()
+        }
         return h.continue
       })
     }

--- a/src/rtracer.js
+++ b/src/rtracer.js
@@ -221,11 +221,7 @@ const hapiPlugin = ({
 
     if (echoHeader) {
       server.ext('onPreResponse', async (request, h) => {
-        if (request.response && request.response.header) {
-          request.response.header(headerName, id())
-        } else if (request.response && request.response.output && request.response.output.headers) {
-          request.response.output.headers[headerName] = id()
-        }
+        request.raw.res.setHeader(headerName, id())
         return h.continue
       })
     }

--- a/src/rtracer.js
+++ b/src/rtracer.js
@@ -221,10 +221,10 @@ const hapiPlugin = ({
 
     if (echoHeader) {
       server.ext('onPreResponse', async (request, h) => {
-        if (request.response && request.response.header) {
-          request.response.header(headerName, id())
-        } else if (request.response && request.response.output && request.response.output.headers) {
+        if (request.response.isBoom) {
           request.response.output.headers[headerName] = id()
+        } else {
+          request.response.header(headerName, id())
         }
         return h.continue
       })

--- a/tests/hapi.test.js
+++ b/tests/hapi.test.js
@@ -349,4 +349,26 @@ describe('cls-rtracer for Hapi', () => {
     expect(res.statusCode).toBe(200)
     expect(res.headers['x-another-req-id']).toEqual(id)
   })
+
+  test('echoes the header when the option is set and an error is thrown', async () => {
+    let id
+
+    server = await setupServer({
+      options: {
+        echoHeader: true
+      },
+      handler: () => {
+        id = rTracer.id()
+        throw new Error(id)
+      }
+    })
+
+    const res = await server.inject({
+      method: 'get',
+      url: '/'
+    })
+
+    expect(res.statusCode).toBe(500)
+    expect(res.headers['x-request-id']).toEqual(id)
+  })
 })


### PR DESCRIPTION
Hapi does something weird whenever there's an error and the response becomes a Hapi [Boom] object instead of a Hapi Response. That causes an annoying issue where there's two different ways to set the response header. This adds some guards and sets the header for the error case.

[Boom]: https://github.com/hapijs/boom