### PR TITLE
Ci typing validation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "test-ci": "npm run lint && npm run test",
+    "test-ci": "npm run check-type && npm run lint && npm run test",
     "cover": "jest --coverage --coverageReporters=text-lcov | coveralls",
     "test": "jest",
-    "lint": "standard"
+    "lint": "standard",
+    "check-type": "tsc index.d.ts"
   },
   "repository": {
     "type": "git",
@@ -63,6 +64,7 @@
   },
   "devDependencies": {
     "@hapi/hapi": "^20.0.1",
+    "@types/node": "^14.14.31",
     "coveralls": "^3.1.0",
     "express": "^4.17.1",
     "fastify": "^3.7.0",
@@ -72,6 +74,7 @@
     "koav1": "npm:koa@^1.7.0",
     "standard": "^15.0.0",
     "supertest": "^5.0.0",
+    "typescript": "^4.2.2",
     "winston": "^3.3.3"
   }
 }


### PR DESCRIPTION
Adds type definition file validation to ci.

Note: Using tsd package is an option. Not sure we need it. 

Closes #17 