### PR TITLE
Update uuid, relax semver bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "logging"
   ],
   "dependencies": {
-    "uuid": "8.3.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@hapi/hapi": "^20.0.1",


### PR DESCRIPTION
This is a small thing, but it feels like the right thing to do, especially since each instance of the uuid modules allocates a separate buffer for cached values.