### PR TITLE
Fix EventEmitter wrapper to remove the correct listener

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -43,34 +43,36 @@ function wrapEmitter (emitter, asyncResource) {
         emitter[wrappedSymbol] = wrapped
       }
       const wrappedHandler = asyncResource.runInAsyncScope.bind(asyncResource, handler, emitter)
-      const existing = wrapped[event]
-      if (existing === undefined) {
-        wrapped[event] = wrappedHandler
-      } else if (typeof existing === 'function') {
-        wrapped[event] = [existing, wrappedHandler]
-      } else {
-        wrapped[event].push(wrappedHandler)
+      let entries = wrapped[event]
+      if (entries === undefined) {
+        entries = []
+        wrapped[event] = entries
       }
+      entries.push([handler, wrappedHandler])
       return original.call(this, event, wrappedHandler)
     })
   }
 
   for (const method of removeMethods) {
     wrapEmitterMethod(emitter, method, (original) => function (event, handler) {
-      let wrappedHandler
+      let wrappedHandler = handler
       const wrapped = emitter[wrappedSymbol]
       if (wrapped !== undefined) {
-        const existing = wrapped[event]
-        if (existing !== undefined) {
-          if (typeof existing === 'function') {
-            wrappedHandler = existing
-            delete wrapped[event]
-          } else {
-            wrappedHandler = existing.pop()
+        const entries = wrapped[event]
+        if (entries !== undefined) {
+          // Match Node's EventEmitter.removeListener: when the same listener
+          // is registered multiple times, the most recently added one is removed.
+          for (let i = entries.length - 1; i >= 0; i--) {
+            if (entries[i][0] === handler) {
+              wrappedHandler = entries[i][1]
+              entries.splice(i, 1)
+              if (entries.length === 0) delete wrapped[event]
+              break
+            }
           }
         }
       }
-      return original.call(this, event, wrappedHandler || handler)
+      return original.call(this, event, wrappedHandler)
     })
   }
 }

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -112,6 +112,51 @@ test('allows registering same listener function to same event', () => {
   }
 })
 
+test('removes the correct wrapper when distinct listeners share an event', () => {
+  const emitter = new EventEmitter()
+  const asyncResource = new AsyncResource('foobar')
+
+  let aCalled = 0
+  let bCalled = 0
+  const listenerA = () => aCalled++
+  const listenerB = () => bCalled++
+
+  wrapEmitter(emitter, asyncResource)
+  emitter.on('foo', listenerA)
+  emitter.on('foo', listenerB)
+
+  emitter.removeListener('foo', listenerA)
+  emitter.emit('foo')
+
+  expect(aCalled).toEqual(0)
+  expect(bCalled).toEqual(1)
+})
+
+test('removes the most recent wrapper when the same listener is removed multiple times', () => {
+  const emitter = new EventEmitter()
+  const asyncResource = new AsyncResource('foobar')
+
+  let called = 0
+  const listener = () => called++
+
+  wrapEmitter(emitter, asyncResource)
+  emitter.on('foo', listener)
+  emitter.on('foo', listener)
+  emitter.on('foo', listener)
+
+  emitter.removeListener('foo', listener)
+  emitter.emit('foo')
+  expect(called).toEqual(2)
+
+  emitter.removeListener('foo', listener)
+  emitter.emit('foo')
+  expect(called).toEqual(3)
+
+  emitter.removeListener('foo', listener)
+  emitter.emit('foo')
+  expect(called).toEqual(3)
+})
+
 test('allows registering self-deregistering listener function', () => {
   const emitter = new EventEmitter()
   const asyncResource = new AsyncResource('foobar')


### PR DESCRIPTION
Fixes #77

The remove path popped the most-recently-added wrapper for an event regardless of which handler was being removed, which silently swapped wrappers when distinct listeners shared an event. With koa 3.1.0 switching to Stream.pipeline (adding 'close'/'finish'/'error' on res alongside pino-http's), pino-http's 'close' listener survived its own removeListener call and ran a second time on the post-finish 'close'.

Track each registration as an explicit (handler, wrappedHandler) pair and remove the last matching pair, mirroring Node's removeListener semantics.