### PR TITLE
Prepare v2.6.4 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18, 20, 21]
+        node-version: [20, 22, 24]
     name: Build with Node ${{ matrix.node-version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
 
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -27,6 +27,6 @@ jobs:
         run: npm run cover
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Request Tracer - Express & Koa middlewares and Fastify & Hapi plugins for CLS-ba
 
 Automatically generates a UUID V1 value as the id for each request and stores it in `AsyncLocalStorage` (CLS core API, see [this blog post](https://itnext.io/one-node-js-cls-api-to-rule-them-all-1670ac66a9e8)). Optionally, if the request contains `X-Request-Id` header, uses its value instead. Allows to obtain the generated request id anywhere in your routes later and use it for logging or any other purposes.
 
-Tested and works fine with Express v4, Fastify v2 and v3, Koa v1 and v2, and Hapi v18.
+Tested and works fine with Express v5, Fastify v2 and v5, Koa v1 and v3, and Hapi v21.
 
 ## Supported Node.js versions
 
-As `cls-rtracer` v2 depends on [`AsyncLocalStorage API`](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynclocalstorage), it requires Node.js 12.17.0+, 13.14.0+, or 14.0.0+. If you happen to use an older Node.js version, you should use [`cls-rtracer` v1](https://github.com/puzpuzpuz/cls-rtracer/tree/1.x) which is based on [`cls-hooked`](https://github.com/jeff-lewis/cls-hooked).
+`cls-rtracer` v3 requires Node.js 16.0.0 or newer.
 
 ## How to use it - Step 1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cls-rtracer",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Express & Koa middlewares and Fastify & Hapi plugins for CLS-based request id generation, batteries included",
   "author": {
     "name": "Andrey Pechkurov",
@@ -43,7 +43,7 @@
     "cover": "jest --coverage --coverageReporters=lcov",
     "test": "jest",
     "lint": "standard",
-    "check-type": "tsc index.d.ts"
+    "check-type": "tsc --types node index.d.ts"
   },
   "repository": {
     "type": "git",
@@ -63,17 +63,17 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@hapi/hapi": "^21.3.7",
-    "@types/node": "^16.18.91",
-    "express": "^4.19.0",
-    "fastify": "^4.26.2",
+    "@hapi/hapi": "^21.4.9",
+    "@types/node": "^24.12.3",
+    "express": "^5.2.1",
+    "fastify": "^5.8.5",
     "fastifyv2": "npm:fastify@^2.15.3",
-    "jest": "^29.7.0",
-    "koa": "^2.15.1",
+    "jest": "^30.4.2",
+    "koa": "^3.2.0",
     "koav1": "npm:koa@^1.7.0",
-    "standard": "^17.1.0",
-    "supertest": "^6.3.4",
-    "typescript": "^5.4.2",
-    "winston": "^3.12.0"
+    "standard": "^17.1.2",
+    "supertest": "^7.2.2",
+    "typescript": "^6.0.3",
+    "winston": "^3.19.0"
   }
 }


### PR DESCRIPTION
- Bump devDependencies to latest majors (express 5, fastify 5, koa 3, jest 30, supertest 7, typescript 6, @types/node 24, hapi 21.4)
- Drop support for Node.js <20; engines now requires >=20.0.0
- CI matrix updated to Node 20/22/24; bump GH actions to current majors (checkout v4, setup-node v4, coverallsapp/github-action v2)
- Pass --types node to tsc since it no longer auto-discovers @types/node without a tsconfig
- README: refresh "Tested with" line and Supported Node.js section