### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:puzpuzpuz/cls-rtracer.git"
+    "url": "git+https://github.com/puzpuzpuz/cls-rtracer.git"
   },
   "keywords": [
     "express",


### PR DESCRIPTION
## Summary
- update the package repository metadata to use the public HTTPS GitHub URL
- keep the change limited to package metadata

## Validation
- node package metadata assertion
- git diff --check
- git ls-remote https://github.com/puzpuzpuz/cls-rtracer.git HEAD
- npm pack --dry-run --ignore-scripts --json
